### PR TITLE
Add tests.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,9 +10,15 @@ run-data: # test with basic check against real data
 run-report: # test with basic check, plus report file option
 	python diffsanity.py check --report missing.txt fakeroot/src/ fakeroot/backup/
 
+# -- tests --
+
+.PHONY: test
+test:
+	pytest ./test/
+
 # -- tools --
 
-compile: # compile requirements with uv
+compile: # compile requirements with uv, `pip install uv`
 	uv pip compile requirements.in >requirements.txt
 
 TEMP_FILE := $(shell mktemp)

--- a/requirements-dev.in
+++ b/requirements-dev.in
@@ -1,2 +1,3 @@
 ipython
 jupyter
+pytest

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -65,6 +65,8 @@ idna==3.7
     #   httpx
     #   jsonschema
     #   requests
+iniconfig==2.0.0
+    # via pytest
 ipykernel==6.29.4
     # via
     #   jupyter
@@ -183,6 +185,7 @@ packaging==24.0
     #   jupyterlab
     #   jupyterlab-server
     #   nbconvert
+    #   pytest
     #   qtconsole
     #   qtpy
 pandocfilters==1.5.1
@@ -196,6 +199,8 @@ pillow==10.3.0
     # via pi-heif
 platformdirs==4.2.1
     # via jupyter-core
+pluggy==1.5.0
+    # via pytest
 prometheus-client==0.20.0
     # via jupyter-server
 prompt-toolkit==3.0.43
@@ -218,6 +223,7 @@ pygments==2.18.0
     #   jupyter-console
     #   nbconvert
     #   qtconsole
+pytest==8.2.0
 python-dateutil==2.9.0.post0
     # via
     #   arrow

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -1,0 +1,13 @@
+import os
+import sys
+import warnings
+
+with warnings.catch_warnings():
+    warnings.simplefilter("ignore")
+    import fs
+fs  # ignore
+
+TEST_ROOT = os.path.abspath(os.path.dirname(__file__))
+PROJECT_ROOT = os.path.dirname(TEST_ROOT)
+
+sys.path.insert(0, PROJECT_ROOT)

--- a/test/data.py
+++ b/test/data.py
@@ -1,0 +1,95 @@
+import functools
+import os
+
+import fs
+
+TEST_ROOT = os.path.abspath(os.path.dirname(__file__))
+DATA_ROOT = os.path.join(TEST_ROOT, "data")
+
+
+class Data:
+    """Load precomputed metadata of files at .../test/data/{name}.
+
+    Example invocation to generate MD5SUMS on Linux:
+
+        find . -type f                    |
+          grep -v SUMS$                   |
+          xargs -L 1 -P $(nproc) md5sum   |
+          sort -k 2,2                     |
+          tee BYTE_MD5SUMS
+    """
+
+    def __init__(self, name):
+        self.path = os.path.join(DATA_ROOT, name)
+        self.md5_dict = self.load(os.path.join(self.path, "BYTE_MD5SUMS"))
+        self.verify_filepaths_match(self.path, self.md5_dict)
+
+    def __iter__(self):
+        return self.iter(algo=None)  # Use default algo.
+
+    def file_and_checksum(self, folder, algo=None):
+        "File, checksum pairs relative to top-level folder of test data."
+        algo = algo or "md5"
+        assert algo in ("md5",)
+        checksum_dict = getattr(self, f"{algo}_dict")
+
+        file_and_checksum = []
+        for path, checksum in checksum_dict.items():
+            if path.startswith(f"./{folder}/"):
+                _, _, subpath = path.split("/", maxsplit=2)
+                file_and_checksum.append((subpath, checksum))
+
+        assert file_and_checksum
+        return file_and_checksum
+
+    def iter(self, folder=None, algo=None):
+        """Iterate all top-level, include FS object between path, checksum."""
+        if folder is not None:
+            folder_list = [folder]
+        else:
+            folder_list = self.toplevel()
+
+        pairs = functools.partial(self.file_and_checksum, algo=algo)
+        some = None
+
+        with fs.open_fs(self.path) as data_fs:
+            for folder in folder_list:
+                for file_path, checksum in pairs(folder):
+                    some = True
+                    path = f"{folder}/{file_path}"
+                    yield path, data_fs, checksum
+
+        assert some, "No data."
+
+    def load(self, path):
+        "Load file to checksum mapping from SUMS file at given path."
+        file_to_checksum = {}
+        with open(path) as f:
+            for line in f:
+                checksum, file_path = line.strip().split(maxsplit=1)
+                assert file_path.startswith("."), "Use relative paths."
+                file_to_checksum[file_path] = checksum
+        return file_to_checksum
+
+    def toplevel(self):
+        "Get list of top-level folders within test data."
+        for _, toplevel, _ in os.walk(self.path):
+            return toplevel
+
+    def verify_filepaths_match(self, root, file_to_checksum):
+        "Assert checksum file list matches filesystem content."
+        metadata = set(file_to_checksum.keys())
+
+        filesystem = set()
+        folder_fs = fs.open_fs(root)
+        for path in sorted(folder_fs.walk.files()):
+            path = path.lstrip("/")
+            if "/" not in path and path.endswith("SUMS"):
+                continue
+            filesystem.add(f"./{path}")
+
+        metadata_only = filesystem - metadata
+        filesystem_only = metadata - filesystem
+
+        assert not metadata_only, metadata_only
+        assert not filesystem_only, filesystem_only

--- a/test/data/simple/BYTE_MD5SUMS
+++ b/test/data/simple/BYTE_MD5SUMS
@@ -2,4 +2,4 @@
 3f52d078e6dbaa62fe5c1fe5dceafa5d  ./dest/sub/shorter.txt
 746308829575e17c3331bbcb00c0898b  ./src/one/hello.txt
 3f52d078e6dbaa62fe5c1fe5dceafa5d  ./src/two/a-much-longer-filename.txt
-2ff66bc28e8ac8f8a6c14a41bec9a2d1  ./src/two/more/missing.txt
+2ff66bc28e8ac8f8a6c14a41bec9a2d1  ./src/two/more/src-only.txt

--- a/test/data/simple/BYTE_MD5SUMS
+++ b/test/data/simple/BYTE_MD5SUMS
@@ -1,0 +1,5 @@
+746308829575e17c3331bbcb00c0898b  ./dest/hello.txt
+3f52d078e6dbaa62fe5c1fe5dceafa5d  ./dest/sub/shorter.txt
+746308829575e17c3331bbcb00c0898b  ./src/one/hello.txt
+3f52d078e6dbaa62fe5c1fe5dceafa5d  ./src/two/a-much-longer-filename.txt
+2ff66bc28e8ac8f8a6c14a41bec9a2d1  ./src/two/more/missing.txt

--- a/test/data/simple/dest/hello.txt
+++ b/test/data/simple/dest/hello.txt
@@ -1,0 +1,1 @@
+Hello, world!

--- a/test/data/simple/dest/sub/shorter.txt
+++ b/test/data/simple/dest/sub/shorter.txt
@@ -1,0 +1,1 @@
+For review of stdout column sizing.

--- a/test/data/simple/src/one/hello.txt
+++ b/test/data/simple/src/one/hello.txt
@@ -1,0 +1,1 @@
+Hello, world!

--- a/test/data/simple/src/two/a-much-longer-filename.txt
+++ b/test/data/simple/src/two/a-much-longer-filename.txt
@@ -1,0 +1,1 @@
+For review of stdout column sizing.

--- a/test/data/simple/src/two/more/src-only.txt
+++ b/test/data/simple/src/two/more/src-only.txt
@@ -1,0 +1,1 @@
+Keep this out of destination in order to test missing source.

--- a/test/unit/test_bytes.py
+++ b/test/unit/test_bytes.py
@@ -1,0 +1,9 @@
+from diffsanity import get_file_bytes
+
+from data import Data
+
+
+def test_unknown():
+    for file_path, fs_obj, _ in Data("simple"):
+        assert file_path.endswith(".txt")
+        assert get_file_bytes(file_path, fs_obj) is None

--- a/test/unit/test_hash.py
+++ b/test/unit/test_hash.py
@@ -1,0 +1,38 @@
+import os
+
+from diffsanity import generate_hashes, get_file_hash
+
+from data import Data
+
+
+HELLO_MD5 = "746308829575e17c3331bbcb00c0898b"
+
+
+def test_data():
+    simple = Data("simple")
+
+    dest = dict(simple.file_and_checksum("dest"))
+    assert len(dest) > 1
+    assert dest["hello.txt"] == HELLO_MD5
+
+    src = dict(simple.file_and_checksum("src"))
+    assert len(src) > 1
+    assert src["one/hello.txt"] == HELLO_MD5
+
+    assert len(list(simple)) == len(src) + len(dest)
+    assert len(list(simple.iter())) == len(src) + len(dest)
+    assert len(list(simple.iter("src"))) == len(src)
+    assert len(list(simple.iter("dest"))) == len(dest)
+
+
+def test_simple_hash():
+    for file_path, fs_obj, checksum in Data("simple"):
+        assert get_file_hash(file_path, fs_obj) == checksum
+
+
+def test_simple_hashes():
+    simple = Data("simple")
+    for directory in simple.toplevel():
+        hashes = generate_hashes(os.path.join(simple.path, directory))
+        assert HELLO_MD5 in hashes
+        assert len(hashes) > 1

--- a/test/unit/test_primary_key.py
+++ b/test/unit/test_primary_key.py
@@ -1,0 +1,17 @@
+from diffsanity import generate_primary_key
+
+from data import Data
+
+
+def test_consistency():
+    generated = {}
+
+    for file_path, fs_obj, _ in Data("simple"):
+        generated[file_path] = generate_primary_key(file_path, fs_obj)
+
+    prev = None
+    for file_path, fs_obj, _ in Data("simple"):
+        key = generate_primary_key(file_path, fs_obj)
+        assert key == generated[file_path]
+        assert key != prev
+        prev = key


### PR DESCRIPTION
These tests have symmetry with the file API common within diffsanity: a file path relative to a PyFilesystem object.

Key design considerations:

* Add datasets by name at `test/data/{name}/`; access by `name`.
* Iterate files by `test/data/{name}/{folder}/` in order to accommodate multiple source folders.
* Use precomputed checksums for high confidence.
  - Use `BYTES_MD5SUMS` file convention for parity with the topic of bytes vs exif+bytes.
  - Assert alignment of the SUMS file with files on disk. 
* Parameterize `algo` to make API adaptable to additional hashing algorithms.
* Keep tests dumb, without boilerplate, and test the test code.

The refactor ahead retains the file path + fs object API, so these tests should enable productivity and assurance without friction.