### PR TITLE
Split stdio, use click I/O, exit non-zero.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ run-report: # test with basic check, plus report file option
 
 .PHONY: test
 test:
-	pytest ./test/
+	pytest --cov=. ./test/
 
 # -- tools --
 

--- a/diffsanity.py
+++ b/diffsanity.py
@@ -194,11 +194,11 @@ def generate_hashes(directory):
             else:
                 cache_hit = ""
                 file_hash = get_file_hash(path, fs_obj)
-            print(f"{path} | ", end="", flush=True)
+            click.echo(f"{path} | ", nl=False)
             # {cache_hit} is just "*" when there is a hit
-            print(f"{cache_hit}{file_hash}", end="", flush=True)
-            print(f" | {primary_key}", end="", flush=True)
-            print("", flush=True)
+            click.echo(f"{cache_hit}{file_hash}", nl=False)
+            click.echo(f" | {primary_key}", nl=False)
+            click.echo("")
             hashes[file_hash] = path
     click.info(" Done.")
     return hashes
@@ -232,7 +232,7 @@ def manifest(folder):
         return
     click.info(f"{filehash_sum} file found ({num_entries} entries). Printing first 5:")
     for i, (primary_key, hash) in enumerate(cachedict.items(), 1):
-        print(primary_key, hash)
+        click.echo(primary_key, hash)
         if i == 5:
             return
 

--- a/diffsanity.py
+++ b/diffsanity.py
@@ -1,4 +1,3 @@
-import functools
 import datetime as dt
 import os
 from hashlib import md5
@@ -181,7 +180,7 @@ def get_manifest(directory):
 
 def generate_hashes(directory):
     """Generate hashes for all files in the directory."""
-    click.info(f"Generating hashes for {directory} ('*' means cache hit):")
+    info(f"Generating hashes for {directory} ('*' means cache hit):")
     hashes = {}
     cachedict = get_manifest(directory)
     with fs.open_fs(directory) as fs_obj:
@@ -194,19 +193,31 @@ def generate_hashes(directory):
             else:
                 cache_hit = ""
                 file_hash = get_file_hash(path, fs_obj)
-            click.echo(f"{path} | ", nl=False)
+            out(f"{path} | ", nl=False)
             # {cache_hit} is just "*" when there is a hit
-            click.echo(f"{cache_hit}{file_hash}", nl=False)
-            click.echo(f" | {primary_key}", nl=False)
-            click.echo("")
+            out(f"{cache_hit}{file_hash}", nl=False)
+            out(f" | {primary_key}", nl=False)
+            out("")
             hashes[file_hash] = path
-    click.info(" Done.")
+    info(" Done.")
     return hashes
 
 
-# Patch click with variations of `echo`.
-click.info = functools.partial(click.echo, err=True)
-click.err = functools.partial(click.echo, err=True)
+def out(*a, **kw):
+    "Print to stdout."
+    click.echo(*a, **kw)
+
+
+def err(*a, **kw):
+    "Print to stderr."
+    kw.setdefault("err", True)
+    click.echo(*a, **kw)
+
+
+def info(*a, **kw):
+    "Log informational detail."
+    kw.setdefault("err", True)
+    click.echo(*a, **kw)
 
 
 @click.group()
@@ -217,7 +228,7 @@ def cli():
 @cli.command()
 def version():
     """Display the version of the tool."""
-    click.echo("diffsanity version 0.1")
+    out("diffsanity version 0.1")
 
 
 @cli.command()
@@ -228,11 +239,11 @@ def manifest(folder):
     num_entries = len(cachedict)
     filehash_sum = f"{folder}/filehash.sum"
     if num_entries == 0:
-        click.err(f"No {filehash_sum} file found, or no manifest entries in file.")
+        err(f"No {filehash_sum} file found, or no manifest entries in file.")
         return
-    click.info(f"{filehash_sum} file found ({num_entries} entries). Printing first 5:")
+    info(f"{filehash_sum} file found ({num_entries} entries). Printing first 5:")
     for i, (primary_key, hash) in enumerate(cachedict.items(), 1):
-        click.echo(primary_key, hash)
+        out(primary_key, hash)
         if i == 5:
             return
 
@@ -261,20 +272,20 @@ def check(source_folder, backup_folder, report):
 
     def iterate_hashes():
         for hash, path in missing_hashes.items():
-            click.err(f"Missing {path} with hash {hash}")
+            err(f"Missing {path} with hash {hash}")
             full_path = os.path.join(source_folder, path.lstrip("/"))
             yield full_path, path, hash
 
     if not missing_hashes:
-        click.info("All hashes from source folder are present in the backup folder.")
+        info("All hashes from source folder are present in the backup folder.")
         return
 
-    click.err("Some hashes are missing in the backup folder:")
+    err("Some hashes are missing in the backup folder:")
     if report:
         with open(report, "w") as file:
             for full_path, _, _ in iterate_hashes():
                 file.write(f"{full_path}\n")
-            click.err(f"Missing file report generated in: {report}")
+            err(f"Missing file report generated in: {report}")
     else:
         for _, _, _ in iterate_hashes():
             # iterate_hashes() will generate some basic console output

--- a/diffsanity.py
+++ b/diffsanity.py
@@ -280,6 +280,8 @@ def check(source_folder, backup_folder, report):
             # iterate_hashes() will generate some basic console output
             pass
 
+    click.get_current_context().exit(1)
+
 
 if __name__ == "__main__":
     cli()

--- a/requirements-dev.in
+++ b/requirements-dev.in
@@ -1,3 +1,4 @@
 ipython
 jupyter
 pytest
+pytest-cov

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -40,6 +40,8 @@ comm==0.2.2
     # via
     #   ipykernel
     #   ipywidgets
+coverage==7.5.1
+    # via pytest-cov
 debugpy==1.8.1
     # via ipykernel
 decorator==5.1.1
@@ -224,6 +226,8 @@ pygments==2.18.0
     #   nbconvert
     #   qtconsole
 pytest==8.2.0
+    # via pytest-cov
+pytest-cov==5.0.0
 python-dateutil==2.9.0.post0
     # via
     #   arrow

--- a/test/integration/test_simple.py
+++ b/test/integration/test_simple.py
@@ -1,0 +1,33 @@
+import os
+
+from click.testing import CliRunner
+from diffsanity import check
+
+from data import Data
+
+BOTH = [
+    "/hello.txt",
+    "/one/hello.txt",
+    "/sub/shorter.txt",
+    "/two/a-much-longer-filename.txt",
+]
+
+MISSING = [
+    "/two/more/src-only.txt",
+]
+
+
+def test_simple():
+    simple = Data("simple")
+    src = os.path.join(simple.path, "src")
+    dest = os.path.join(simple.path, "dest")
+
+    runner = CliRunner(mix_stderr=False)
+    result = runner.invoke(check, [src, dest])
+
+    for file_path in BOTH:
+        assert file_path in result.stdout
+        assert file_path not in result.stderr
+
+    for file_path in MISSING:
+        assert file_path in result.stderr

--- a/test/integration/test_simple.py
+++ b/test/integration/test_simple.py
@@ -31,3 +31,5 @@ def test_simple():
 
     for file_path in MISSING:
         assert file_path in result.stderr
+
+    assert result.exit_code != 0


### PR DESCRIPTION
Use stdout only for data output. Given that stdio has only two output streams, this makes the concession that informational logging goes to stderr. The advantage of this approach is that stdout can be redirected or piped for additional processing.

For example:

```
python diffsanity.py check test/data/simple/{src,dest} |
  tee checksums.txt &&
  sort checksums.txt | column --table > checksums.table.txt &&
  mv checksums.table.txt checksums.txt
```

<details>
<summary>... which uses `column` from util-linux with the following output.</summary>

```
/hello.txt                       |  746308829575e17c3331bbcb00c0898b  |  ('2024-05-14T04:47:08',  'hello.txt',                   '14')
/one/hello.txt                   |  746308829575e17c3331bbcb00c0898b  |  ('2024-05-14T04:47:08',  'hello.txt',                   '14')
/sub/shorter.txt                 |  3f52d078e6dbaa62fe5c1fe5dceafa5d  |  ('2024-05-14T04:47:08',  'shorter.txt',                 '36')
/two/a-much-longer-filename.txt  |  3f52d078e6dbaa62fe5c1fe5dceafa5d  |  ('2024-05-14T04:47:08',  'a-much-longer-filename.txt',  '36')
/two/more/src-only.txt           |  2ff66bc28e8ac8f8a6c14a41bec9a2d1  |  ('2024-05-14T04:47:08',  'src-only.txt',                '62')
```

To undo padding when processing such a file:

```python
import csv
import re
with open("checksums.txt") as fd:
    reader = csv.reader(fd, delimiter="|", quoting=csv.QUOTE_NONE)
    [[re.sub(" +", " ", cell.strip()) for cell in row] for row in reader]
```
</details>

(The use of a file in this example, instead of piping directly, is to avoid sorting on the very large datasets typical of diffsanity.)

I'm not an advocate for using `click` inside the function--it belongs at the edges--but consistency is important both in terms of semantics and user experience. And for testing, which must be a bug in `click.testing` where stderr is empty except for `click.echo(..., err=True)`.

Finally, use a non-zero exit code on a failed diff.

Along the way, add code coverage and an integration test.